### PR TITLE
Issue#3 fix

### DIFF
--- a/server/helpers/customErrorClass.js
+++ b/server/helpers/customErrorClass.js
@@ -1,0 +1,10 @@
+class CustomError extends Error {
+  constructor(message = "Something went wrong", code = 500) {
+    super();
+    this.message = message;
+    this.code = code;
+    this.name = "Logic Error";
+  }
+}
+
+module.exports = CustomError;

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,6 +1,7 @@
 const router = require("express").Router();
 const Post = require("../models/Post");
 const User = require("../models/User");
+const CustomError = require("../helpers/customErrorClass");
 
 //create a post
 
@@ -22,10 +23,10 @@ router.put("/:id", async (req, res) => {
       await post.updateOne({ $set: req.body });
       res.status(200).json("the post has been updated");
     } else {
-      res.status(403).json("you can update only your post");
+      throw new CustomError("You can update only your post", 403);
     }
   } catch (err) {
-    res.status(500).json(err);
+    res.status(err.code || 500).json(err.message);
   }
 });
 //delete a post
@@ -37,10 +38,10 @@ router.delete("/:id", async (req, res) => {
       await post.deleteOne();
       res.status(200).json("the post has been deleted");
     } else {
-      res.status(403).json("you can delete only your post");
+      throw new CustomError("You can delete only your post", 403);
     }
   } catch (err) {
-    res.status(500).json(err);
+    res.status(err.code || 500).json(err.message);
   }
 });
 //like / dislike a post


### PR DESCRIPTION
The problem was the absence of a return statement after the response which allowed the code after the response line to run and change headers which is not allowed by express. 

There are 2 ways to solve it, 
- add a `return` statement after each early response
- throw an error and send a response from the catch block. 

The second approach is more efficient but it has a drawback that the response headers could not be set dynamically by throwing a simple `Error` object. To overcome that I created a new `CustomError` class which could take in the response code and response message as parameters.

I also cleaned some controller code to make them more readable